### PR TITLE
Content not within correct `<div>`'s

### DIFF
--- a/compoments/report-repair/contact-details.js
+++ b/compoments/report-repair/contact-details.js
@@ -47,7 +47,7 @@ const ContactDetails = ({handleChange, values}) => {
     <header>
       <title>{title} - {serviceName}</title>
     </header>
-    <div>
+    <div className='govuk-grid-column-two-thirds'>
       <RadioFieldSet name={name}
         title={title}
         options={options}

--- a/compoments/report-repair/contact-person.js
+++ b/compoments/report-repair/contact-person.js
@@ -15,7 +15,7 @@ const ContactPerson = ({handleChange, values}) => {
     <header>
       <title>{title} - {serviceName}</title>
     </header>
-    <div>
+    <div className='govuk-grid-column-two-thirds'>
       <TextInput
         value={values.contactPersonNumber}
         name={'phone-number'}

--- a/compoments/report-repair/contact-person.js
+++ b/compoments/report-repair/contact-person.js
@@ -25,7 +25,6 @@ const ContactPerson = ({handleChange, values}) => {
         hint="Please enter a UK landline or mobile phone number"
         title={title}
         buttonText={'Continue'}
-        long={true}
         onKeyPress={phoneOnKeyPress}
       ></TextInput>
     </div>

--- a/compoments/report-repair/postcode.js
+++ b/compoments/report-repair/postcode.js
@@ -14,7 +14,7 @@ const Postcode = ({handleChange, values}) => {
     <header>
       <title>{title} - {serviceName}</title>
     </header>
-    <div>
+    <div className='govuk-grid-column-two-thirds'>
       <TextInput
         value={values.postcode}
         name={'postcode'}

--- a/compoments/report-repair/repair-description.js
+++ b/compoments/report-repair/repair-description.js
@@ -82,7 +82,7 @@ const RepairDescription = ({handleChange, values}) => {
         {title}
       </h1>
       <div className={error.text ? 'govuk-form-group--error' : 'govuk-form-group'}>
-        <form action="" className='govuk-!-padding-0'>
+        <form action="">
           <label className="govuk-label" htmlFor="description">
             <div>
               <p>Please describe:</p>

--- a/compoments/textInput.js
+++ b/compoments/textInput.js
@@ -68,7 +68,7 @@ class TextInput extends Component {
       <>
         <h1 className="govuk-heading-l">{this.title}</h1>
         <div className={this.state.error.msg ? 'govuk-form-group--error' : 'govuk-form-group'}>
-          <form action="" className={(this.long ? 'govuk-grid-column-two-thirds':'govuk-grid-column-one-third')}>
+          <form action="">
             <span id={`${this.name}-error`}
               className="govuk-error-message govuk-!-margin-bottom-0">
               {this.state.error.msg}

--- a/compoments/textInput.js
+++ b/compoments/textInput.js
@@ -68,7 +68,7 @@ class TextInput extends Component {
       <>
         <h1 className="govuk-heading-l">{this.title}</h1>
         <div className={this.state.error.msg ? 'govuk-form-group--error' : 'govuk-form-group'}>
-          <form action="" className={(this.long ? 'govuk-grid-column-two-thirds':'govuk-grid-column-one-third')+' govuk-!-padding-0'}>
+          <form action="" className={(this.long ? 'govuk-grid-column-two-thirds':'govuk-grid-column-one-third')}>
             <span id={`${this.name}-error`}
               className="govuk-error-message govuk-!-margin-bottom-0">
               {this.state.error.msg}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,7 +2,6 @@ import '../styles/globals.css';
 import '../styles/globals.scss';
 import React from 'react';
 import App from 'next/app';
-import Link from 'next/link';
 import { useEffect } from 'react';
 import Header from '../compoments/header';
 
@@ -16,9 +15,7 @@ function MyApp({ Component, pageProps, err }) {
     <>
       <Header></Header>
       <div className="govuk-width-container">
-        <main className="govuk-main-wrapper govuk-!-padding-0">
-          <Component {...pageProps} err={err} />
-        </main>
+        <Component {...pageProps} err={err} />
       </div>
       <footer className="govuk-footer " role="contentinfo">
         <div className="govuk-width-container ">

--- a/pages/report-repair/[route].js
+++ b/pages/report-repair/[route].js
@@ -593,10 +593,10 @@ function ReportRepair() {
   return (
     <>
       {showBack && <BackLink href="#" onClick={prevStep}>Back</BackLink>}
-      <div className="govuk-!-margin-top-7">
+      <main className="govuk-main-wrapper">
         {formError}
         {component()}
-      </div>
+      </main>
     </>
   )
 }


### PR DESCRIPTION
This moves the content to be within a `<div class="govuk-grid-row"> and <div class="govuk-grid-column-two-thirds">`, so that the content does not spill into the gutters of the main container.

1. This also removes instances of `govuk-!-padding-0` being used.
2. It also moves the back button outside of the main element.
3. Removes a duplicate of `govuk-grid-column-two-thirds` and `govuk-grid-column-one-thirds.` that forced the text input size.

Pages changed:
- /report-repair/postcode
- /report-repair/contact-person
- /report-repair/contact-details
- /report-repair/repair-description

Component changed:
- Text Input