### PR TITLE
190 Remove usages of margin overrides

### DIFF
--- a/compoments/loader.js
+++ b/compoments/loader.js
@@ -8,7 +8,7 @@ export default function Loader({}) {
         <title>Loading - {serviceName}</title>
       </header>
       <div className="loader"></div>
-      <h4 className="govuk-!-text-align-centre  govuk-!-margin-bottom-7">
+      <h4 className="govuk-!-text-align-centre">
         Loading
       </h4>
     </>

--- a/compoments/radioFieldSet.js
+++ b/compoments/radioFieldSet.js
@@ -105,44 +105,65 @@ class RadioFieldSet extends Component {
               </h1>
             </legend>
             {this.hintText && <div id={`hint-text-${this.name}`} className='govuk-hint'>{this.hintText}</div>}
-            <span id={`${this.name}-error`}
-              className="govuk-error-message">
+            <span
+              id={`${this.name}-error`}
+              className="govuk-error-message"
+            >
               {this.state.error}
             </span>
             <div className={this.conditional ? 'govuk-radios--conditional' : 'govuk-radios'}>
               {this.options.map((o, i) => (
                 <>
-                  {this.includeOrDivider(i) && <TextDivider text='or' /> }
-                  <div className="govuk-radios__item" key={`radio-item-${i}`}>
-                    <input className="govuk-radios__input govuk-input--width-10"
-                      id={`${this.name}-${i}`} name={this.name}
-                      type="radio" value={o.value}
+                  {this.includeOrDivider(i) && <TextDivider text='or' />}
+                  <div
+                    className="govuk-radios__item"
+                    key={`radio-item-${i}`}
+                  >
+                    <input
+                      className="govuk-radios__input govuk-input--width-10"
+                      id={`${this.name}-${i}`}
+                      name={this.name}
+                      type="radio"
+                      value={o.value}
                       defaultChecked={o.checked}
                       onChange={this.setValue.bind(this)}
                       onClick={() => { this.setState({ activeError: false }) }}
                       data-aria-controls={this.getConditionalId(i)}
                     />
-                    <label className="govuk-label govuk-radios__label"
-                      htmlFor={`${this.name}-${i}`}>
+                    <label
+                      className="govuk-label govuk-radios__label"
+                      htmlFor={`${this.name}-${i}`}
+                    >
                       {o.title}
                     </label>
                   </div>
                   {o.conditional &&
-                  <div key={`radio-conditional-${i}`}
+                  <div
+                    key={`radio-conditional-${i}`}
                     className={`govuk-radios__conditional ${this.state.value[this.name] != o.value && 'govuk-visually-hidden'}`}
-                    id={this.getConditionalId(i)}>
-                    <div className={this.hasConditionalError(i) ? 'govuk-form-group--error' : 'govuk-form-group'} key={`conditional-${i}`}>
-                      <label className="govuk-hint" htmlFor={this.getConditionalInputId(o.value)}>
+                    id={this.getConditionalId(i)}
+                  >
+                    <div
+                      className={this.hasConditionalError(i) ? 'govuk-form-group--error' : 'govuk-form-group'}
+                      key={`conditional-${i}`}
+                    >
+                      <label
+                        className="govuk-hint"
+                        htmlFor={this.getConditionalInputId(o.value)}
+                      >
                         {o.conditional.label}
                       </label>
                       {this.hasConditionalError(i) &&
-                        <span id={`${this.name}-conditional-error`}
+                        <span
+                          id={`${this.name}-conditional-error`}
                           className="govuk-error-message">
                           {this.state.conditionalError.msg}
                         </span>
                       }
-                      <input className="govuk-input govuk-!-width-one-third"
-                        id={this.getConditionalInputId(o.value)} name={this.getConditionalInputId(o.value)}
+                      <input
+                        className="govuk-input govuk-!-width-one-third"
+                        id={this.getConditionalInputId(o.value)}
+                        name={this.getConditionalInputId(o.value)}
                         type={o.conditional.type}
                         defaultValue={this.conditionalValue[o.value]}
                         onChange={(e) => {

--- a/compoments/radioFieldSet.js
+++ b/compoments/radioFieldSet.js
@@ -6,6 +6,14 @@ import React from 'react';
 import ErrorSummary from './errorSummary';
 import { serviceName } from '../helpers/constants';
 
+const TextDivider = ({text}) => {
+  return <div id="final-divider" className="govuk-radios__divider">{text}</div>
+}
+
+TextDivider.propTypes = {
+  text: PropTypes.string.isRequired,
+};
+
 class RadioFieldSet extends Component {
   constructor(props) {
     super(props);
@@ -104,7 +112,7 @@ class RadioFieldSet extends Component {
             <div className={this.conditional ? 'govuk-radios--conditional' : 'govuk-radios'}>
               {this.options.map((o, i) => (
                 <>
-                  {this.includeOrDivider(i) && <div id="final-divider" className="govuk-radios__divider">or</div>}
+                  {this.includeOrDivider(i) && <TextDivider text='or' /> }
                   <div className="govuk-radios__item" key={`radio-item-${i}`}>
                     <input className="govuk-radios__input govuk-input--width-10"
                       id={`${this.name}-${i}`} name={this.name}
@@ -178,6 +186,7 @@ RadioFieldSet.propTypes = {
   errorText: PropTypes.string,
   conditionalValue: PropTypes.object
 };
+
 export default RadioFieldSet;
 
 

--- a/compoments/radioFieldSet.js
+++ b/compoments/radioFieldSet.js
@@ -98,14 +98,14 @@ class RadioFieldSet extends Component {
             </legend>
             {this.hintText && <div id={`hint-text-${this.name}`} className='govuk-hint'>{this.hintText}</div>}
             <span id={`${this.name}-error`}
-              className="govuk-error-message govuk-!-margin-bottom-0">
+              className="govuk-error-message">
               {this.state.error}
             </span>
             <div className={this.conditional ? 'govuk-radios--conditional' : 'govuk-radios'}>
               {this.options.map((o, i) => (
-                <span key={i}>
-                  {this.includeOrDivider(i) ? <div id="final-divider" className="govuk-radios__divider">or</div> : <div className="govuk-!-margin-bottom-2"></div>}
-                  <div className="govuk-radios__item">
+                <>
+                  {this.includeOrDivider(i) && <div id="final-divider" className="govuk-radios__divider">or</div>}
+                  <div className="govuk-radios__item" key={`radio-item-${i}`}>
                     <input className="govuk-radios__input govuk-input--width-10"
                       id={`${this.name}-${i}`} name={this.name}
                       type="radio" value={o.value}
@@ -119,7 +119,8 @@ class RadioFieldSet extends Component {
                       {o.title}
                     </label>
                   </div>
-                  {o.conditional && <div
+                  {o.conditional &&
+                  <div key={`radio-conditional-${i}`}
                     className={`govuk-radios__conditional ${this.state.value[this.name] != o.value && 'govuk-visually-hidden'}`}
                     id={this.getConditionalId(i)}>
                     <div className={this.hasConditionalError(i) ? 'govuk-form-group--error' : 'govuk-form-group'} key={`conditional-${i}`}>
@@ -144,7 +145,7 @@ class RadioFieldSet extends Component {
                       />
                     </div>
                   </div>}
-                </span>
+                </>
               ))}
             </div>
 

--- a/compoments/report-repair/confirmation.js
+++ b/compoments/report-repair/confirmation.js
@@ -32,7 +32,6 @@ const Confirmation = ({ requestId, confirmation }) => {
         <TextLink href="/">
           Report another issue
         </TextLink>
-        <div className="govuk-!-margin-bottom-9"></div>
       </div>
     </div>
   );

--- a/compoments/report-repair/confirmation.js
+++ b/compoments/report-repair/confirmation.js
@@ -29,9 +29,11 @@ const Confirmation = ({ requestId, confirmation }) => {
           We will assess your repair and may be in touch to ask follow-up
           questions.
         </p>
-        <TextLink href="/">
+        <p>
+          <TextLink href="/">
           Report another issue
-        </TextLink>
+          </TextLink>
+        </p>
       </div>
     </div>
   );

--- a/compoments/report-repair/confirmation.js
+++ b/compoments/report-repair/confirmation.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React from 'react';
 import TextLink from '../textLink';
 import {serviceName} from '../../helpers/constants';
 

--- a/compoments/report-repair/confirmation.js
+++ b/compoments/report-repair/confirmation.js
@@ -29,7 +29,7 @@ const Confirmation = ({ requestId, confirmation }) => {
           We will assess your repair and may be in touch to ask follow-up
           questions.
         </p>
-        <p>
+        <p className="govuk-body">
           <TextLink href="/">
           Report another issue
           </TextLink>

--- a/compoments/report-repair/repair-description.js
+++ b/compoments/report-repair/repair-description.js
@@ -125,20 +125,22 @@ const RepairDescription = ({handleChange, values}) => {
             </div>
           </div>
         </label>
-        <div className={error.text ? 'govuk-form-group--error' : 'govuk-form-group'}>
-          <label className="govuk-label govuk-label--m" htmlFor="description">
+        <div className='govuk-character-count'>
+          <div className={error.text ? 'govuk-form-group--error' : 'govuk-form-group'}>
+            <label className="govuk-label govuk-label--m" htmlFor="description">
             Description of problem
-          </label>
-          <span id={'description-error'}
-            className="govuk-error-message">
-            {error.text}
-          </span>
-          <textarea className={`govuk-textarea ${error.text && 'govuk-textarea--error'} govuk-!-margin-bottom-0`} id={repairDescriptionTextInputId}
-            name="description" type="text" onChange={TextChange} defaultValue={text}
-            rows="5"></textarea>
-          <div id="with-hint-info"
-            className={`${textLimit - textAreaCount < 0 ? 'govuk-error-message' : 'govuk-hint'} govuk-character-count__message`}
-            aria-live="polite">{generateCharacterCountText()}
+            </label>
+            <span id={'description-error'}
+              className="govuk-error-message">
+              {error.text}
+            </span>
+            <textarea className={`govuk-textarea ${error.text && 'govuk-textarea--error'}`} id={repairDescriptionTextInputId}
+              name="description" type="text" onChange={TextChange} defaultValue={text}
+              rows="5"></textarea>
+            <div id="with-hint-info"
+              className={`${textLimit - textAreaCount < 0 ? 'govuk-error-message' : 'govuk-hint'} govuk-character-count__message`}
+              aria-live="polite">{generateCharacterCountText()}
+            </div>
           </div>
         </div>
       </form>

--- a/compoments/report-repair/repair-description.js
+++ b/compoments/report-repair/repair-description.js
@@ -5,6 +5,52 @@ import imageToBase64 from 'image-to-base64/browser';
 import {serviceName} from '../../helpers/constants';
 import ErrorSummary from '../errorSummary';
 
+const CharacterCount = ({errorText, hasExceededTextLimit, onChange, repairDescriptionTextInputId, text, textAreaCount, textLimit}) => {
+
+  const generateCharacterCountText = () => {
+    const characterCountDifference = textLimit - textAreaCount;
+    const absoluteCharacterCountDifference = `${Math.abs(characterCountDifference)}`;
+    const suffix = `${characterCountDifference < 0 ? 'too many' : 'remaining'}`;
+    const characterWord = `character${absoluteCharacterCountDifference == 1 ? '' : 's'}`;
+    return `You have ${absoluteCharacterCountDifference} ${characterWord} ${suffix}`
+  }
+
+  return (
+    <div className='govuk-character-count'>
+      <div className={errorText ? 'govuk-form-group--error' : 'govuk-form-group'}>
+        <label className="govuk-label govuk-label--m" htmlFor="description">
+            Description of problem
+        </label>
+        <span id={'description-error'}
+          className="govuk-error-message">
+          {errorText}
+        </span>
+        <textarea
+          className={`govuk-textarea ${errorText && 'govuk-textarea--error'}`}
+          id={repairDescriptionTextInputId}
+          name="description" type="text"
+          onChange={(e) => onChange(e)}
+          defaultValue={text}
+          rows="5"></textarea>
+        <div id="with-hint-info"
+          className={`${hasExceededTextLimit ? 'govuk-error-message' : 'govuk-hint'} govuk-character-count__message`}
+          aria-live="polite">{generateCharacterCountText()}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+CharacterCount.propTypes = {
+  errorText: PropTypes.string.isRequired,
+  hasExceededTextLimit: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+  repairDescriptionTextInputId: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  textAreaCount: PropTypes.number.isRequired,
+  textLimit:PropTypes.number.isRequired,
+}
+
 const RepairDescription = ({handleChange, values}) => {
   const [error, setError] = useState({text: undefined, img: undefined});
   const [activeError, setActiveError] = useState(false);
@@ -83,14 +129,6 @@ const RepairDescription = ({handleChange, values}) => {
     }
   }
 
-  function generateCharacterCountText() {
-    const characterCountDifference = textLimit - textAreaCount;
-    const absoluteCharacterCountDifference = `${Math.abs(characterCountDifference)}`;
-    const suffix = `${characterCountDifference < 0 ? 'too many' : 'remaining'}`;
-    const characterWord = `character${absoluteCharacterCountDifference == 1 ? '' : 's'}`;
-    return `You have ${absoluteCharacterCountDifference} ${characterWord} ${suffix}`
-  }
-
   const getErrorSummaryTextAndLocation = () => {
     const errorSummaryTextAndLocation = [];
     error.text && errorSummaryTextAndLocation.push({text: error.text, location: `#${repairDescriptionTextInputId}`});
@@ -125,24 +163,15 @@ const RepairDescription = ({handleChange, values}) => {
             </div>
           </div>
         </label>
-        <div className='govuk-character-count'>
-          <div className={error.text ? 'govuk-form-group--error' : 'govuk-form-group'}>
-            <label className="govuk-label govuk-label--m" htmlFor="description">
-            Description of problem
-            </label>
-            <span id={'description-error'}
-              className="govuk-error-message">
-              {error.text}
-            </span>
-            <textarea className={`govuk-textarea ${error.text && 'govuk-textarea--error'}`} id={repairDescriptionTextInputId}
-              name="description" type="text" onChange={TextChange} defaultValue={text}
-              rows="5"></textarea>
-            <div id="with-hint-info"
-              className={`${textLimit - textAreaCount < 0 ? 'govuk-error-message' : 'govuk-hint'} govuk-character-count__message`}
-              aria-live="polite">{generateCharacterCountText()}
-            </div>
-          </div>
-        </div>
+        <CharacterCount
+          errorText={error.text}
+          hasExceededTextLimit={textLimit - textAreaCount < 0}
+          onChange={TextChange}
+          repairDescriptionTextInputId={repairDescriptionTextInputId}
+          text={text}
+          textAreaCount={textAreaCount}
+          textLimit={textLimit}
+        />
       </form>
       <div className={error.img ? 'govuk-form-group--error' : 'govuk-form-group'}>
         <h3 className="govuk-heading-m">
@@ -182,8 +211,6 @@ const RepairDescription = ({handleChange, values}) => {
     </div>
   </div>
 };
-
-
 
 RepairDescription.propTypes = {
   storeAddresses: PropTypes.func,

--- a/compoments/summaryList.js
+++ b/compoments/summaryList.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import Link from 'next/link'
+
 export default function SummaryList ({summary, goToStep}) {
 
-  return(<dl className="govuk-summary-list govuk-!-margin-bottom-9">
+  return(<dl className="govuk-summary-list">
     {summary.map((o, i) => (
       <div className="govuk-summary-list__row" key={i}>
         <dt className="govuk-summary-list__key">

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,7 +10,7 @@ export default function Home() {
   const title = 'Request a repair';
   return (
     <main className="govuk-main-wrapper" id='main-content'>
-      <div className="govuk-grid-row govuk-body-m govuk-!-margin-top-7">
+      <div className="govuk-grid-row govuk-body-m">
         <header>
           <title>
             {title} - {serviceName}
@@ -21,7 +21,6 @@ export default function Home() {
           <h2 className={'govuk-heading-m'}>Before you start</h2>
           <WarningText
             testid="landing-page-report-limit-warning"
-            className="govuk-!-margin-top-4"
           >
           This service can only be used to request one repair at a time to a
           council property.
@@ -49,7 +48,6 @@ export default function Home() {
           </p>
           <Details
             summary="What is a communal area?"
-            className="govuk-!-margin-top-6"
             data-testid="landing-page-communal-prompt"
           >
             <div data-testid="landing-page-communal-info">
@@ -82,7 +80,6 @@ export default function Home() {
           </WarningText>
           <Details
             summary="What is an emergency?"
-            className="govuk-!-margin-top-6"
             testid="landing-page-emergency-prompt"
           >
             <div data-testid="landing-page-emergency-info">


### PR DESCRIPTION
Components with removed classes:

- `Loader`,
- `RadioFieldSet`,
- `Confirmation`,
- `RepairDescription`,
- `SummaryList`,
- `Home`.

To improve readability:

1. `CharacterCount` was moved into a separate component in `RepairDescription`,
2. `TextDivider` was moved into a separate component in `RadioFieldSet`.