### PR TITLE
Add secondary button style to globals.scss

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -9,3 +9,11 @@
       background-color:  #204d74
   }
 }
+
+.govuk-button--secondary {
+  background-color: #f3f2f1;
+  border-radius: 4px;
+  &:hover {
+      background-color:  #b1b4b6
+  }
+}


### PR DESCRIPTION
I created a new button style in `globals.scss` for the secondary button used in `repair-availability.js`.
I did not make any changes to `repair-availability.js`.