### PR TITLE
Generate unique values for contact us early exit value

### DIFF
--- a/pages/report-repair/[route].js
+++ b/pages/report-repair/[route].js
@@ -163,7 +163,7 @@ function ReportRepair() {
   }
 
   const getUniqueOptionValue = (value, index) => {
-    const hasUniqueValueId = [emergencyValue, notEligibleNonEmergencyValue, unableToBookValue]
+    const hasUniqueValueId = [emergencyValue, notEligibleNonEmergencyValue, unableToBookValue, contactUsValue]
     return hasUniqueValueId.includes(value) ? `${value}-${index}` : value
   }
 


### PR DESCRIPTION
This change was missed as part of #37 and is required to ensure unique values are generated for "contact us" early exit options.