### PR TITLE
260 contact details page

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cd api/ && cp example.env .env
 Start the development function (still in the api directory)
 
 ```bash
-cd nvm use && yarn start
+nvm use && yarn start
 ```
 
 > if the function doesn't start try switching your node version to 14.0.0

--- a/flow.js
+++ b/flow.js
@@ -28,7 +28,7 @@ class Flow {
       'repair-location': { prevStep: 'address', nextStep: repairTriageNextSteps},
       'repair-problems': { prevStep: 'repair-location', nextStep: repairTriageNextSteps},
       'repair-problem-best-description': { prevStep: 'repair-problems', nextStep: repairTriageNextSteps},
-      'repair-description': {prevStep: true, nextStep: isMvpReleaseVersion()? 'contact-details' : 'repair-image-upload'},
+      'repair-description': {prevStep: true, nextStep: isMvpReleaseVersion()? 'contact-person' : 'repair-image-upload'},
       'repair-image-upload': { prevStep: 'repair-description', nextStep: 'contact-person'},
       'contact-person': {prevStep: 'repair-description', nextStep:'contact-details'},
       'contact-details': {prevStep: 'contact-person', nextStep: 'repair-availability'},

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint",
     "test": "jest tests/unit",
     "lint:fix": "eslint --fix */**/*.js tests/**/*.js",
-    "cy:open": "cypress open",
-    "cy:run": "cypress run --env appVersion=full",
-    "cy:runmvp": "cypress run --env appVersion=mvp  --spec 'tests/cypress/integration/reportRepair/repairDescriptionMvp.spec.js'",
+    "cy:open": "cypress open --env CYPRESS_RELEASE_VERSION=full",
+    "cy:run": "cypress run --env CYPRESS_RELEASE_VERSION=full",
+    "cy:runmvp": "cypress run --env CYPRESS_RELEASE_VERSION=mvp  --spec 'tests/cypress/integration/reportRepair/repairDescriptionMvp.spec.js'",
     "test:integration": "start-server-and-test start http://localhost:3000 cy:open",
     "test:headless:integration": "yarn build && start-server-and-test start http://localhost:3000 cy:run",
     "test:headless:integration:mvp": "yarn build && start-server-and-test start http://localhost:3000 cy:runmvp"


### PR DESCRIPTION
When the user goes from the "How should we confirm the appointment?" page in the MVP build,
they are now directed to the Appointment selection page.

Also fixed a typo in the readme and the cypress test commands