### PR TITLE
Conditionally add a custom domain resource

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,6 +32,7 @@ resource "azurerm_static_site" "hrostaticwebapp" {
 }
 
 resource "azurerm_static_site_custom_domain" "hrostaticwebapp" {
+  count           = var.custom_domain_name == "" ? 0 : 1
   static_site_id  = azurerm_static_site.hrostaticwebapp.id
   domain_name     = var.custom_domain_name
   validation_type = "cname-delegation"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,5 +38,6 @@ variable "sku_size" {
 }
 
 variable "custom_domain_name" {
-  type = string
+  type    = string
+  default = ""
 }


### PR DESCRIPTION
If no custom domain name is given as a variable, the default behaviour is for terrraform to not add the resource.

This is to allow any adopters of the service to run the service without needing to add a custom domain if they don't have one.