### PR TITLE
176: Small code fixes

### DIFF
--- a/compoments/report-repair/address.js
+++ b/compoments/report-repair/address.js
@@ -99,12 +99,7 @@ const Address = ({handleChange, values}) => {
   </div>
 };
 
-Address.defaultProps = {
-  addresses: []
-};
-
 Address.propTypes = {
-  addresses: PropTypes.array,
   values: PropTypes.object,
   handleChange: PropTypes.func,
 }

--- a/compoments/report-repair/address.js
+++ b/compoments/report-repair/address.js
@@ -88,7 +88,7 @@ const Address = ({handleChange, values}) => {
             ))}
           </Select>
         </div>
-        <p class="govuk-body">
+        <p className='govuk-body'>
           <TextLink href="not-eligible">I can&apos;t find my address on this list</TextLink>
         </p>
         <br/>

--- a/compoments/report-repair/communal.js
+++ b/compoments/report-repair/communal.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import Details from '../details';
 import RadioFieldSet from '../radioFieldSet';
 import React from 'react';
 import {serviceName} from '../../helpers/constants';

--- a/tests/cypress/integration/reportRepair/emergencyRepair.spec.js
+++ b/tests/cypress/integration/reportRepair/emergencyRepair.spec.js
@@ -6,7 +6,7 @@ const goToRepairEmergency = () => {
 }
 
 describe('emergency repair', () => {
-  context('xxxxxxx', () => {
+  context('emergency repair', () => {
     before(goToRepairEmergency)
     it('displays the title', () => {
       cy.contains('Your repair could be an emergency');


### PR DESCRIPTION
Small code changes that I noticed while doing 176:

1. change `class` to `className`,
2. remove unused prop `addresses` from `propTypes`,
3. remove unused import of `Details`,
4. fix test name.