### PR TITLE
311 api env vars

### DIFF
--- a/.github/workflows/azure-static-web-apps-purple-desert-05060ea03.yml
+++ b/.github/workflows/azure-static-web-apps-purple-desert-05060ea03.yml
@@ -144,11 +144,21 @@ jobs:
           echo "token=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .sentryclirc
           cp .sentryclirc api/.sentryclirc
 
-      - name: Set up api environment variables
+      - name: Set up api environment variables for staging
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'staging'}}
         run: |
           cd api
           touch .env
-          echo "NODE_ENV=${{ (github.event_name == 'pull_request' && 'staging') || ('production') }}" >> .env
+          echo "REPAIRS_API_BASE_URL=${{secrets.REPAIRS_API_BASE_URL_STAGING}}"" >> .env
+          echo "REPAIRS_API_IDENTIFIER=${{secrets.REPAIRS_API_IDENTIFIER_STAGING}}"" >> .env
+      
+      - name: Set up api environment variables for production   
+        if: ${{ github.event_name != 'pull_request' && github.event_name != 'staging'}}
+        run: |
+          cd api
+          touch .env
+          echo "REPAIRS_API_BASE_URL=${{secrets.REPAIRS_API_BASE_URL}}"" >> .env
+          echo "REPAIRS_API_IDENTIFIER=${{secrets.REPAIRS_API_IDENTIFIER}}"" >> .env
 
       - name: Build And Deploy
         id: builddeploy

--- a/.github/workflows/azure-static-web-apps-purple-desert-05060ea03.yml
+++ b/.github/workflows/azure-static-web-apps-purple-desert-05060ea03.yml
@@ -145,18 +145,20 @@ jobs:
           cp .sentryclirc api/.sentryclirc
 
       - name: Set up api environment variables for staging
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'staging'}}
+        if: github.event_name == 'pull_request'
         run: |
           cd api
           touch .env
+          echo "# Staging Environment API Configuration"
           echo "REPAIRS_API_BASE_URL=${{secrets.REPAIRS_API_BASE_URL_STAGING}}"" >> .env
           echo "REPAIRS_API_IDENTIFIER=${{secrets.REPAIRS_API_IDENTIFIER_STAGING}}"" >> .env
       
       - name: Set up api environment variables for production   
-        if: ${{ github.event_name != 'pull_request' && github.event_name != 'staging'}}
+        if: github.event_name != 'pull_request'
         run: |
           cd api
           touch .env
+          echo "# Production Environment API Configuration"
           echo "REPAIRS_API_BASE_URL=${{secrets.REPAIRS_API_BASE_URL}}"" >> .env
           echo "REPAIRS_API_IDENTIFIER=${{secrets.REPAIRS_API_IDENTIFIER}}"" >> .env
 

--- a/.github/workflows/azure-static-web-apps-purple-desert-05060ea03.yml
+++ b/.github/workflows/azure-static-web-apps-purple-desert-05060ea03.yml
@@ -150,8 +150,8 @@ jobs:
           cd api
           touch .env
           echo "# Staging Environment API Configuration"
-          echo "REPAIRS_API_BASE_URL=${{secrets.REPAIRS_API_BASE_URL_STAGING}}"" >> .env
-          echo "REPAIRS_API_IDENTIFIER=${{secrets.REPAIRS_API_IDENTIFIER_STAGING}}"" >> .env
+          echo "REPAIRS_API_BASE_URL=${{secrets.REPAIRS_API_BASE_URL_STAGING}}" >> .env
+          echo "REPAIRS_API_IDENTIFIER=${{secrets.REPAIRS_API_IDENTIFIER_STAGING}}" >> .env
       
       - name: Set up api environment variables for production   
         if: github.event_name != 'pull_request'
@@ -159,8 +159,8 @@ jobs:
           cd api
           touch .env
           echo "# Production Environment API Configuration"
-          echo "REPAIRS_API_BASE_URL=${{secrets.REPAIRS_API_BASE_URL}}"" >> .env
-          echo "REPAIRS_API_IDENTIFIER=${{secrets.REPAIRS_API_IDENTIFIER}}"" >> .env
+          echo "REPAIRS_API_BASE_URL=${{secrets.REPAIRS_API_BASE_URL}}" >> .env
+          echo "REPAIRS_API_IDENTIFIER=${{secrets.REPAIRS_API_IDENTIFIER}}" >> .env
 
       - name: Build And Deploy
         id: builddeploy

--- a/api/gateways/apiRequester.js
+++ b/api/gateways/apiRequester.js
@@ -3,12 +3,10 @@ require('dotenv').config()
 module.exports = axios => {
   return {
     makeGetRequest: ({uri, params ={}}) =>{
-      var identifier = process.env.NODE_ENV === 'production' ? process.env.REPAIRS_API_IDENTIFIER : process.env.REPAIRS_API_IDENTIFIER_STAGING
-      var baseUrl = process.env.NODE_ENV === 'production' ? process.env.REPAIRS_API_BASE_URL: process.env.REPAIRS_API_BASE_URL_STAGING;
       const axiosInstance = axios.create({
-        baseURL: baseUrl
+        baseURL: process.env.REPAIRS_API_BASE_URL
       })
-      return axiosInstance.post(`/authentication?identifier=${identifier}`)
+      return axiosInstance.post(`/authentication?identifier=${process.env.REPAIRS_API_IDENTIFIER}`)
         .then(response => {
           var jwt = response.data;
           axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${jwt}`;
@@ -19,12 +17,10 @@ module.exports = axios => {
     },
 
     makePostRequest: ({uri, body ={}}) =>{
-      var identifier = process.env.NODE_ENV === 'production' ? process.env.REPAIRS_API_IDENTIFIER : process.env.REPAIRS_API_IDENTIFIER_STAGING
-      var baseUrl = process.env.NODE_ENV === 'production' ? process.env.REPAIRS_API_BASE_URL: process.env.REPAIRS_API_BASE_URL_STAGING;
       const axiosInstance = axios.create({
-        baseURL: baseUrl
+        baseURL: process.env.REPAIRS_API_BASE_URL
       })
-      return axiosInstance.post(`/authentication?identifier=${identifier}`)
+      return axiosInstance.post(`/authentication?identifier=${process.env.REPAIRS_API_IDENTIFIER}`)
         .then(response => {
           var jwt = response.data;
           axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${jwt}`;

--- a/compoments/footer.js
+++ b/compoments/footer.js
@@ -26,7 +26,7 @@ const Footer = () => {
   ]
 
   return (
-    <footer className="govuk-footer " role="contentinfo" data-testid={`NODE_ENV: ${ process.env.NODE_ENV } NEXT_PUBLIC_APP_ENV: ${process.env.NEXT_PUBLIC_APP_ENV}`}>
+    <footer className="govuk-footer " role="contentinfo">
       <div className="govuk-width-container ">
         <h2 className="govuk-visually-hidden">Support links</h2>
         <ul className="govuk-footer__inline-list">

--- a/tests/unit/gateways/apiRequester.test.js
+++ b/tests/unit/gateways/apiRequester.test.js
@@ -2,25 +2,16 @@ describe('apiRequester', () => {
   let apiRequester;
   let mockedPost;
   let mockedGet;
-  let mockedCreate;
   const api_url = 'https://repairs.api'
   const api_identifier = 'magic key';
-  const api_url_staging = 'https://repairs.api.staging'
-  const api_identifier_staging = 'magic key staging';
   let mockedAxiosInstance;
   const jwt = '~~~jwt~~~';
   const uri = '/request/uri/'
-  const params = {
-    a: 1, b: 2
-  }
 
   describe('when api is up', () => {
     beforeAll(() => {
       process.env.REPAIRS_API_BASE_URL = api_url
       process.env.REPAIRS_API_IDENTIFIER = api_identifier
-      process.env.REPAIRS_API_BASE_URL_STAGING = api_url_staging
-      process.env.REPAIRS_API_IDENTIFIER_STAGING = api_identifier_staging
-      process.env.NODE_ENV = 'production'
 
       mockedPost = jest.fn().mockImplementation(() => Promise.resolve({data: jwt}));
       mockedGet = jest.fn().mockImplementation();
@@ -33,7 +24,7 @@ describe('apiRequester', () => {
           }
         }
       }
-      mockedCreate = jest.fn(()=>{return mockedAxiosInstance});
+      const mockedCreate = jest.fn(()=>{return mockedAxiosInstance});
 
       const mockAxios = {
         create: mockedCreate
@@ -43,7 +34,9 @@ describe('apiRequester', () => {
     });
 
     test('a get request is made with headers', async () => {
-
+      const params = {
+        a: 1, b: 2
+      }
       await apiRequester.makeGetRequest({uri, params});
 
       expect(mockedPost).toHaveBeenCalledWith(
@@ -56,39 +49,10 @@ describe('apiRequester', () => {
 
     });
 
-
-    test('axios create is called with correct base url for production', async () => {
-      process.env.NODE_ENV = 'production'
-      await apiRequester.makeGetRequest({uri, params});
-      expect(mockedCreate).toHaveBeenCalledWith({"baseURL": `https://repairs.api`})
-    });
-
-    test('axios create is called with correct base url for staging', async () => {
-      process.env.NODE_ENV = 'staging'
-      await apiRequester.makeGetRequest({uri, params});
-      expect(mockedCreate).toHaveBeenCalledWith({"baseURL": `https://repairs.api.staging`})
-    });
-
-    test('a get request is made with staging identifier', async () => {
-
-      process.env.NODE_ENV = 'staging'
-      await apiRequester.makeGetRequest({uri, params});
-
-      expect(mockedPost).toHaveBeenCalledWith(
-        `/authentication?identifier=${api_identifier_staging}`
-      )
-
-      expect(mockedAxiosInstance.defaults.headers.common['Authorization']).toEqual(`Bearer ${jwt}`);
-
-      expect(mockedGet).toHaveBeenCalledWith(uri, {'params': params})
-
-    });    
-
     test('a post request is made with headers', async () => {
       const body = {
         a: 1, b: 2
       }
-      process.env.NODE_ENV = 'production'
       await apiRequester.makePostRequest({uri, body});
 
       expect(mockedPost).toHaveBeenNthCalledWith(1, `/authentication?identifier=${api_identifier}`);


### PR DESCRIPTION
Set repairs API config in pipeline and remove extra debug.
Update code to use the configured API settings and remove logic around process.env.NODE_ENV. 
This logic has now been moved to the Github pipeline and means that a separate manual stage to add the config to the static web app is no longer needed.

Needs a change to the documentation to reflect this.