### PR TITLE
Some fixes for displaying existing communal repairs

### DIFF
--- a/compoments/report-repair/communal-repairs.js
+++ b/compoments/report-repair/communal-repairs.js
@@ -36,7 +36,7 @@ const CommunalRepairs = ({ handleChange, values}) => {
             <tbody className="govuk-table__body">
               {data?.map((repair, i) => (
                 <tr className="govuk-table__row">
-                  <th scope="row" className="govuk-table__header" data-cy={`communal-repairs-location-${i}`}>{repair.location.display}</th>
+                  <td className="govuk-table__cell" data-cy={`communal-repairs-location-${i}`}>{repair.location.display}</td>
                   <td className="govuk-table__cell" data-cy={`communal-repairs-problem-${i}`}>{repair.problem.display}</td>
                   <td className="govuk-table__cell" data-cy={`communal-repairs-issue-${i}`}>{repair.issue.display}</td>
                   <td className="govuk-table__cell" data-cy={`communal-repairs-description-${i}`}>{repair.description.text}</td>

--- a/compoments/report-repair/communal-repairs.js
+++ b/compoments/report-repair/communal-repairs.js
@@ -46,7 +46,7 @@ const CommunalRepairs = ({ handleChange, values}) => {
                   <td className="govuk-table__cell" data-cy={`communal-repairs-location-${i}`}>{repair.location.display}</td>
                   <td className="govuk-table__cell" data-cy={`communal-repairs-problem-${i}`}>{repair.problem.display}</td>
                   <td className="govuk-table__cell" data-cy={`communal-repairs-issue-${i}`}>{repair.issue.display}</td>
-                  <td className="govuk-table__cell" data-cy={`communal-repairs-description-${i}`}>{repair.description.text}</td>
+                  <td className="govuk-table__cell" data-cy={`communal-repairs-description-${i}`}>{repair.description.location}</td>
                 </tr>
               ))}
             </tbody>

--- a/compoments/report-repair/communal-repairs.js
+++ b/compoments/report-repair/communal-repairs.js
@@ -5,6 +5,8 @@ import ComponentHeader from '../componentHeader';
 import useSWR from 'swr';
 import {fetcher} from '../../helpers/fetcher';
 import Loader from '../loader';
+import Error from "../error";
+import {customerServicesTelephoneNumber} from '../../globals';
 
 
 const CommunalRepairs = ({ handleChange, values}) => {
@@ -12,6 +14,11 @@ const CommunalRepairs = ({ handleChange, values}) => {
   const Continue = val => {
     handleChange('reportNewCommunalRepair', true);
   }
+
+  if (error) return <Error
+    name="summary"
+    heading="An error occurred while looking for problems reported at this address"
+    body={`Please try again later or call ${customerServicesTelephoneNumber} to complete your repair request`} />
 
   if (!data) return <Loader/>
   const title = 'Problems reported at this address'

--- a/compoments/report-repair/repair-image-upload.js
+++ b/compoments/report-repair/repair-image-upload.js
@@ -53,11 +53,11 @@ const RepairImageUpload = ({ handleChange, values }) => {
     const imageError = selectedFile ? imageValidator(selectedFile) : undefined;
     if (!imageError) {
       return handleChange('description', {
+        ...values.description,
         photo: selectedImage,
         filename: selectedFile ? selectedFile.name: '',
         fileExtension: fileExtension,
         base64img: base64img,
-        text: values?.description?.text || undefined
       });
     } else {
       setSelectedImage(null);

--- a/tests/cypress/integration/reportRepair/communal-repairs.spec.js
+++ b/tests/cypress/integration/reportRepair/communal-repairs.spec.js
@@ -87,7 +87,7 @@ describe('communal repair', () => {
       it('displays first communal-repairs-description', () => {
         cy.get('[data-cy=communal-repairs-description-0]').should(
           'have.contain',
-          'communal kitchen door is hanging off'
+          'First floor kitchen, cupboard next to fridge'
         );
       });
     });

--- a/tests/fixtures/communalRepairs.json
+++ b/tests/fixtures/communalRepairs.json
@@ -22,7 +22,8 @@
     "description": {
       "photoUrl": null,
       "text": "communal kitchen door is hanging off",
-      "base64Image": null
+      "base64Image": null,
+      "location": "First floor kitchen, cupboard next to fridge"
     }
   },
   {


### PR DESCRIPTION
Fixes:
- [Correct formatting of first item in row](https://github.com/Newarkandsherwood/housing-repairs-online-frontend/commit/c4d50af1a91693b5536a21e2cb65e8f3d3b41223) 
- [Add error handling for non-successful API request](https://github.com/Newarkandsherwood/housing-repairs-online-frontend/commit/697e8ad24ac26c347c663946ab4bba31f9074b91) 
- [Display user entered location description instead of text](https://github.com/Newarkandsherwood/housing-repairs-online-frontend/commit/6d6b61a1b4775b39374051f9d7ccc20302092dfb)
- [Retain all previous values stored in description](https://github.com/Newarkandsherwood/housing-repairs-online-frontend/commit/ad226944d1290cc897b1e20193d3a988fec76067)

Have created a single PR for the fixes with each fix in an individual commit as they are disparate from one another.
Let me know if you wish for them to be separated to individual PRs.